### PR TITLE
Implement MergeSort more concisely

### DIFF
--- a/MergeSort/MergeSort.go
+++ b/MergeSort/MergeSort.go
@@ -1,45 +1,27 @@
 package MergeSort
 
-func mergeParts(array []int, leftIndex, divideIndex, rightIndex int) {
-	var tempArray1, tempArray2 []int
-	for i := leftIndex; i <= divideIndex; i++ {
-		tempArray1 = append(tempArray1, array[i])
-	}
-	for i := divideIndex + 1; i <= rightIndex; i++ {
-		tempArray2 = append(tempArray2, array[i])
-	}
-	arrayIndex := leftIndex
-	tempArray1Index := 0
-	tempArray2Index := 0
-	for tempArray1Index != len(tempArray1) && tempArray2Index != len(tempArray2) {
-		if tempArray1[tempArray1Index] <= tempArray2[tempArray2Index] {
-			array[arrayIndex] = tempArray1[tempArray1Index]
-			tempArray1Index += 1
+func merge(left, right []int) []int {
+	merged := make([]int, 0, len(left)+len(right))
+	for len(left) > 0 && len(right) > 0 {
+		if left[0] < right[0] {
+			merged = append(merged, left[0])
+			left = left[1:]
 		} else {
-			array[arrayIndex] = tempArray2[tempArray2Index]
-			tempArray2Index += 1
+			merged = append(merged, right[0])
+			right = right[1:]
 		}
-		arrayIndex += 1
 	}
-	for tempArray1Index < len(tempArray1) {
-		array[arrayIndex] = tempArray1[tempArray1Index]
-		tempArray1Index += 1
-		arrayIndex += 1
-
-	}
-	for tempArray2Index < len(tempArray2) {
-		array[arrayIndex] = tempArray2[tempArray2Index]
-		tempArray2Index += 1
-		arrayIndex += 1
-	}
+	merged = append(merged, left...)
+	merged = append(merged, right...)
+	return merged
 }
 
-func MergeSort(array []int, leftIndex, rightIndex int) {
-	if leftIndex >= rightIndex {
+func MergeSort(array []int) {
+	if len(array) <= 1 {
 		return
 	}
-	divideIndex := int((leftIndex + rightIndex) / 2)
-	MergeSort(array, leftIndex, divideIndex)
-	MergeSort(array, divideIndex+1, rightIndex)
-	mergeParts(array, leftIndex, divideIndex, rightIndex)
+	left, right := array[:len(array)/2], array[len(array)/2:]
+	MergeSort(left)
+	MergeSort(right)
+	copy(array, merge(left, right))
 }


### PR DESCRIPTION
This version reslices the `left` and `right` arrays instead of passing around array indices. This feels like more idiomatic Go to me, but it might not follow the textbook version of mergesort as closely as the old version.