### PR TITLE
fix to DoublyLinkedList.InsertFirst()

### DIFF
--- a/DoublyLinkedList/DoublyLinkedList.go
+++ b/DoublyLinkedList/DoublyLinkedList.go
@@ -13,6 +13,11 @@ type LinkedList struct {
 
 func (list *LinkedList) InsertFirst(i int) {
 	data := &Node{data: i}
+	if list.tail == nil {
+		list.head = data
+		list.tail = data
+		return
+	}
 	if list.head != nil {
 		list.head.prev = data
 		data.next = list.head


### PR DESCRIPTION
The InsertFirst() method is missing an empty list check. I copied the check from InsertLast() and made the needed changes. This fix is the following 5 lines of code:
```
	if list.tail == nil {
		list.head = data
		list.tail = data
		return
	}
```