### PR TITLE
Optimize GetLast() in DoublyLinkedList

### DIFF
--- a/DoublyLinkedList/DoublyLinkedList.go
+++ b/DoublyLinkedList/DoublyLinkedList.go
@@ -113,11 +113,7 @@ func (list *LinkedList) GetLast() (int, bool) {
 	if list.head == nil {
 		return 0, false
 	}
-	current := list.head
-	for current.next != nil {
-		current = current.next
-	}
-	return current.data, true
+	return list.tail.data, true
 }
 
 func (list *LinkedList) GetSize() int {


### PR DESCRIPTION
The GetLast() function traverses through the entire LL to get to the last pointer, when there's already a tail node. The fix gets rid of the traversal and returns the tail node value.
```
func (list *LinkedList) GetLast() (int, bool) {
	if list.head == nil {
		return 0, false
	}
	return list.tail.data, true
}
```